### PR TITLE
Box seal fixes

### DIFF
--- a/lib/salty/box_curve25519xsalsa20poly1305.ex
+++ b/lib/salty/box_curve25519xsalsa20poly1305.ex
@@ -62,7 +62,7 @@ defmodule Salty.Box.Curve25519xsalsa20poly1305 do
   end
 
   def seal(msg, pk) do
-    C.box_curve25519xchacha20poly1305_seal(msg, pk)
+    C.box_curve25519xsalsa20poly1305_seal(msg, pk)
   end
 
   def seal_open(cipher, pk, sk) do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Salty.Mixfile do
   end
 
   defp aliases do
-    [compile: ["compile", &make/1]]
+    [compile: [&make/1, "compile"]]
   end
 
   defp deps do

--- a/src/salty_nif.c
+++ b/src/salty_nif.c
@@ -1147,7 +1147,7 @@ SALTY_FUNC(box_curve25519xsalsa20poly1305_seal_open, 3) DO
     SALTY_CALL_WITHERR(crypto_box_curve25519xsalsa20poly1305_seal_open(
                 msg.data, cipher.data, cipher.size, pk.data, sk.data),
             atom_error_forged, msg);
-END_OK_WITH(cipher);
+END_OK_WITH(msg);
 
 /**
  * CORE hchacha20


### PR DESCRIPTION
Thanks for the library. 

I found a few problems when experimenting with Salty that are fixed by this PR:

1. `Salty.Box.Curve25519xsalsa20poly1305.seal/2` was calling the wrong NIF primitive
2. the NIF function for `box_curve25519xsalsa20poly1305_seal_open` was returning the original ciphertext, not the decrypted plaintext, and
3. Compiling salty was deleting other dependencies.

3 is a bit weird: don't know if its an elixir/mix bug but having the compile alias call `["compile", &make/1]` in that order was deleting other compiled dependencies in my project, i.e. the directories under `_build/dev/lib` were being deleted. This is on Elixir 1.5.2, OTP 20.

Switching the order of the compile commands fixed it (luckily). 