### PR TITLE
Add support for crosscompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Libsodium is licensed under [ISC License](https://github.com/jedisct1/libsodium/
 
 This package is available through [Hex](https://hex.pm/packages/libsalty).
 
+## Requirements
+
+Libsalty requires that libsodium 1.0.12 or later is already installed on your
+system. If you receive compiler warnings or a missing symbol error when trying
+to use libsalty, it's likely that you're running on a system with an old version
+of libsodium.
+
 ## License
 
 Copyright 2017 Project ArteMisc

--- a/lib/salty/nif.ex
+++ b/lib/salty/nif.ex
@@ -1,12 +1,13 @@
 defmodule Salty.Nif do
   @moduledoc false
+  @compile {:autoload, false}
 
   @doc """
   load_nif is called when Salty.Application is started. It loads the libary and
   binds the Elixir module methods to erl_nif calls.
   """
   def load_nif do
-    path = :filename.join([:code.priv_dir(:salty), :erlang.system_info(:system_architecture), "salty_nif"])
+    path = :filename.join([:code.priv_dir(:salty), "salty_nif"])
     case :erlang.load_nif(path, 0) do
       :ok -> :ok
       error -> {:error, error}

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule Salty.Mixfile do
       elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      aliases: aliases(),
+      compilers: [:elixir_make] ++ Mix.compilers(),
+      make_clean: ["clean"],
       description: description(),
       package: package(),
       deps: deps(),
@@ -24,20 +25,11 @@ defmodule Salty.Mixfile do
     [mod: {Salty.Application, []}]
   end
 
-  defp aliases do
-    [compile: [&make/1, "compile"]]
-  end
-
   defp deps do
-    [{:ex_doc, "~> 0.14", only: :dev}]
-  end
-
-  defp make(_) do
-    IO.puts "compiling salty_nif bindings"
-    unless Mix.shell.cmd("make") === 0 do
-      raise Mix.Error, message: "make encountered an error"
-    end
-    IO.puts "compiling salty_nif bindings done"
+    [
+      {:ex_doc, "~> 0.14", only: :dev},
+      {:elixir_make, "~> 0.4", runtime: false}
+    ]
   end
 
   defp description do


### PR DESCRIPTION
I made several updates to make it possible to crosscompile especially for Nerves users. Non-Nerves users should also be able to crosscompile by overriding $CC, $CFLAGS, etc, which should hopefully be familiar from how it works with other projects. 

Most  of the changes involved taking out system architecture detection from the Makefile and nif.ex and then tweaking some of the Makefile variables. I've tested this on OSX and Linux to make sure that I haven't broken non-crosscompiled builds. There are a number of warnings, but they look like they're due to changes in the Erlang interface when dirty NIFs were added.

I also updated mix.exs to use elixir_make to simplify some logic and let me run `mix clean`. This also includes a note about libsodium versions which I ran into on Ubuntu.